### PR TITLE
persist Seq2Seq through keras load - save api

### DIFF
--- a/seq2seq/cells.py
+++ b/seq2seq/cells.py
@@ -60,10 +60,13 @@ class LSTMDecoderCell(ExtendedRNNCell):
 class AttentionDecoderCell(ExtendedRNNCell):
 
     def __init__(self, hidden_dim=None, **kwargs):
+
+        # we have no output_dim prior to calling parent constructor:
         if hidden_dim:
             self.hidden_dim = hidden_dim
         else:
-            self.hidden_dim = self.output_dim
+            self.hidden_dim = kwargs.get('output_dim')
+
         self.input_ndim = 3
         super(AttentionDecoderCell, self).__init__(**kwargs)
 
@@ -115,3 +118,9 @@ class AttentionDecoderCell(ExtendedRNNCell):
         y = Activation(self.activation)(W2(h))
 
         return Model([x, h_tm1, c_tm1], [y, h, c])
+
+    def get_config(self):
+        config = {'hidden_dim': self.hidden_dim}
+        base_config = super(ExtendedRNNCell, self).get_config()
+        config.update(base_config)
+        return config

--- a/seq2seq/cells.py
+++ b/seq2seq/cells.py
@@ -9,11 +9,11 @@ from keras import backend as K
 class LSTMDecoderCell(ExtendedRNNCell):
 
     def __init__(self, hidden_dim=None, **kwargs):
+        super(LSTMDecoderCell, self).__init__(**kwargs)
         if hidden_dim:
             self.hidden_dim = hidden_dim
         else:
             self.hidden_dim = self.output_dim
-        super(LSTMDecoderCell, self).__init__(**kwargs)
 
     def build_model(self, input_shape):
         hidden_dim = self.hidden_dim

--- a/seq2seq/cells.py
+++ b/seq2seq/cells.py
@@ -9,13 +9,15 @@ from keras import backend as K
 class LSTMDecoderCell(ExtendedRNNCell):
 
     def __init__(self, hidden_dim=None, **kwargs):
-        if hidden_dim:
-            self.hidden_dim = hidden_dim
+
+
+        super(LSTMDecoderCell, self).__init__(**kwargs)
 
         # we have no output_dim prior to calling parent constructor:
-        #else:
-        #    self.hidden_dim = self.output_dim
-        super(LSTMDecoderCell, self).__init__(**kwargs)
+        if hidden_dim:
+            self.hidden_dim = hidden_dim
+        else:
+            self.hidden_dim = self.output_dim        
 
     def build_model(self, input_shape):
         hidden_dim = self.hidden_dim
@@ -48,6 +50,11 @@ class LSTMDecoderCell(ExtendedRNNCell):
 
         return Model([x, h_tm1, c_tm1], [y, h, c])
 
+    def get_config(self):
+        config = {'hidden_dim': self.hidden_dim}
+        base_config = super(ExtendedRNNCell, self).get_config()
+        config.update(base_config)
+        return config
 
 class AttentionDecoderCell(ExtendedRNNCell):
 

--- a/seq2seq/cells.py
+++ b/seq2seq/cells.py
@@ -11,13 +11,14 @@ class LSTMDecoderCell(ExtendedRNNCell):
     def __init__(self, hidden_dim=None, **kwargs):
 
 
-        super(LSTMDecoderCell, self).__init__(**kwargs)
-
         # we have no output_dim prior to calling parent constructor:
         if hidden_dim:
             self.hidden_dim = hidden_dim
         else:
-            self.hidden_dim = self.output_dim        
+            self.hidden_dim = kwargs.get('output_dim')
+
+        super(LSTMDecoderCell, self).__init__(**kwargs)
+
 
     def build_model(self, input_shape):
         hidden_dim = self.hidden_dim

--- a/seq2seq/cells.py
+++ b/seq2seq/cells.py
@@ -9,11 +9,13 @@ from keras import backend as K
 class LSTMDecoderCell(ExtendedRNNCell):
 
     def __init__(self, hidden_dim=None, **kwargs):
-        super(LSTMDecoderCell, self).__init__(**kwargs)
         if hidden_dim:
             self.hidden_dim = hidden_dim
-        else:
-            self.hidden_dim = self.output_dim
+
+        # we have no output_dim prior to calling parent constructor:
+        #else:
+        #    self.hidden_dim = self.output_dim
+        super(LSTMDecoderCell, self).__init__(**kwargs)
 
     def build_model(self, input_shape):
         hidden_dim = self.hidden_dim


### PR DESCRIPTION
Added a `get_config` override method to handle `hidden_dim` in `LSTMDecoderCell` and `AttentionDecoderCell`.

Moreover, the constructors of both classes relied on `self.output_dim` to set the value of `hidden_dim` if not supplied. But `self.output_dim` is not available until super constructor has been called. Fixed by accessing directly to kwargs, so that `hidden_dim` is be available when the super constructor calls the `build_model` method.


